### PR TITLE
Updated settings of favonia/cloudflare-ddns

### DIFF
--- a/infrastructure/base/cloudflare-ddns/manifest.yaml
+++ b/infrastructure/base/cloudflare-ddns/manifest.yaml
@@ -37,19 +37,14 @@ spec:
                   key: api_token
             - name: DOMAINS
               value: vandelocht.uk
-            - name: PGID
-              value: "1000"
             - name: PROXIED
               value: "true"
-            - name: PUID
-              value: "1000"
           # image: favonia/cloudflare-ddns:1.10.1
           name: cloudflare-ddns
           securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
             capabilities:
-              add:
-                - SETUID
-                - SETGID
               drop:
                 - all
             readOnlyRootFilesystem: true


### PR DESCRIPTION
Thanks for using my DDNS updater. Since [version 1.13.0 released on 16 July](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown#1130-2024-07-16), the updater has stopped dropping superuser privileges by itself, instead relying on Docker's built-in mechanism to drop those privileges. The new way is safer and more reliable, but it made the old Docker template (which grants `SETUID` and `SETGID`) potentially less secure. I am on a mission to eliminate the old template from the internet. Please help me promote security best practices!

For more information about this design change, please read the [CHANGELOG](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown). If copyright ever matters, this PR itself is licensed under [CC0](https://choosealicense.com/licenses/cc0-1.0/), which should allow you to do whatever you want. Thank you again for your interest in my DDNS updater.

PS: I also recommend setting `allowPrivilegeEscalation: false` under `securityContext`.